### PR TITLE
Update common.sh prevent val to be empty when use usb dac

### DIFF
--- a/srv/http/bash/common.sh
+++ b/srv/http/bash/common.sh
@@ -553,8 +553,13 @@ volumeGet() {
 			pushData volume '{ "type": "'$1'", "val": '$val', "db": '$db' }'
 			[[ -e $dirshm/usbdac ]] && alsactl store # fix: not saved on off / disconnect
 			;;
-		valdb ) echo '{ "val": '$val', "db": '$db' }';;
-		db )    echo $db;;
+		valdb ) 
+			if [[ -z $val]]
+			  val=0
+			fi
+			
+			echo '{ "val": '$val', "db": '$db' }';;
+					db )    echo $db;;
 		* )     echo $val;;
 	esac
 	[[ $val > 0 ]] && rm -rf $dirsystem/volumemute


### PR DESCRIPTION
when using usb dac,
go to setting-player -> will get json param error where volume val not have any value
so i force to gave value to 0 if there is no value set

