### PR TITLE
Update common.sh - prevent value val volume to be empty used usbdac

### DIFF
--- a/srv/http/bash/common.sh
+++ b/srv/http/bash/common.sh
@@ -553,7 +553,11 @@ volumeGet() {
 			pushData volume '{ "type": "'$1'", "val": '$val', "db": '$db' }'
 			[[ -e $dirshm/usbdac ]] && alsactl store # fix: not saved on off / disconnect
 			;;
-		valdb ) echo '{ "val": '$val', "db": '$db' }';;
+		valdb ) 
+  			if [[ -z $val]]; then
+			  val=0
+			fi			
+  			echo '{ "val": '$val', "db": '$db' }';;
 		db )    echo $db;;
 		* )     echo $val;;
 	esac

--- a/srv/http/bash/common.sh
+++ b/srv/http/bash/common.sh
@@ -554,7 +554,7 @@ volumeGet() {
 			[[ -e $dirshm/usbdac ]] && alsactl store # fix: not saved on off / disconnect
 			;;
 		valdb ) 
-  			if [[ -z $val]]; then
+  			if [[ -z $val ]]; then
 			  val=0
 			fi			
   			echo '{ "val": '$val', "db": '$db' }';;

--- a/srv/http/library.php
+++ b/srv/http/library.php
@@ -152,7 +152,7 @@ case 'list':
 	break;
 case 'ls':
 	if ( in_Array( $string, [ 'NAS', 'SD', 'USB' ] ) ) { // file modes - show all dirs in root
-		exec( 'ls -1d /mnt/MPD/'.$string.'/*/ | sed -E -e "s|^/mnt/MPD/(.*)/$|\1|" -e "/NAS.data$/ d"', $ls );
+		exec( 'ls -1d /mnt/MPD/'.$string.'/* | sed -E -e "s|^/mnt/MPD/(.*)/$|\1|" -e "/NAS.data$/ d"', $ls );
 		htmlDirectory( $ls );
 		exit;
 //----------------------------------------------------------------------------------


### PR DESCRIPTION
when using usb dac, json val volume for using usb dac, have empty value.
so i cannot open setting-player menu

this modification is just make val is not empty value and change to 0 only
and i can open the setting-player like before